### PR TITLE
adds Power Fx tag to Power Fx samples

### DIFF
--- a/samples/color-functions/assets/sample.json
+++ b/samples/color-functions/assets/sample.json
@@ -14,7 +14,8 @@
         "url": "https://github.com/pnp/powerfx-samples/tree/main/samples/color-functions#srgbtolin",
         "products": [
             "Power Apps",
-            "Power Platform"
+            "Power Platform",
+            "Power Fx"
         ],
         "tags": [
         "COLOR", "HEX", "DECIMAL", "CONVERT"

--- a/samples/convertbasenumber-functions/assets/sample.json
+++ b/samples/convertbasenumber-functions/assets/sample.json
@@ -12,7 +12,8 @@
     "url": "https://github.com/pnp/powerfx-samples/tree/main/samples/convertbasenumber-functions",
     "products": [
       "Power Apps",
-      "Power Platform"
+      "Power Platform",
+      "Power Fx"
     ],
     "tags": [
       "NUMBER", "HEX", "DECIMAL", "CONVERT"

--- a/samples/date-functions/assets/sample.json
+++ b/samples/date-functions/assets/sample.json
@@ -14,7 +14,8 @@
         "url": "https://github.com/pnp/powerfx-samples/tree/main/samples/date-functions#EndOfQuarter",
         "products": [
             "Power Apps",
-            "Power Platform"
+            "Power Platform",
+            "Power Fx"
         ],
         "tags": [
             "DATE",
@@ -315,7 +316,7 @@
             "DATE",
             "YEAR",
             "LEAP"
-        ],        
+        ],
         "categories": [
             "POWERFX"
         ],

--- a/samples/financial-functions/assets/sample.json
+++ b/samples/financial-functions/assets/sample.json
@@ -14,7 +14,8 @@
         "url": "https://github.com/pnp/powerfx-samples/tree/main/samples/financial-functions#fv",
         "products": [
             "Power Apps",
-            "Power Platform"
+            "Power Platform",
+            "Power Fx"
         ],
         "tags": [
             "NUMBER",

--- a/samples/geolocation-utils/assets/sample.json
+++ b/samples/geolocation-utils/assets/sample.json
@@ -15,7 +15,8 @@
     "url": "https://github.com/pnp/powerfx-samples/tree/main/samples/geolocation-utils#twopoints",
     "products": [
       "Power Apps",
-      "Power Platform"
+      "Power Platform",
+      "Power Fx"
     ],
     "tags": [
       "GEOLOCATION",

--- a/samples/regex-functions/README.md
+++ b/samples/regex-functions/README.md
@@ -25,7 +25,6 @@ The following image shows the custom function (component) properties and a sampl
 
 None
 
-
 ## Solution
 
 Solution|Author(s)

--- a/samples/regex-functions/assets/sample.json
+++ b/samples/regex-functions/assets/sample.json
@@ -12,7 +12,8 @@
     "url": "https://github.com/pnp/powerfx-samples/tree/main/samples/regex-functions#iscurrency",
     "products": [
       "Power Apps",
-      "Power Platform"
+      "Power Platform",
+      "Power Fx"
     ],
     "tags": [
       "TEXT",

--- a/samples/table-functions/README.md
+++ b/samples/table-functions/README.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-This is a `TableUtils` PowerApp Component containing Custom Functions that allow to transform a Record in a Table 
+This is a `TableUtils` PowerApp Component containing Custom Functions that allow to transform a Record in a Table
 
 ![Sample](assets/sonDiffToTableSample.png)
 

--- a/samples/table-functions/assets/sample.json
+++ b/samples/table-functions/assets/sample.json
@@ -1,17 +1,17 @@
 [
     {
         "$schema": "https://developer.microsoft.com/en-us/json-schemas/pnp/samples/v1.0/metadata-schema.json",
-        "name": "pnp-powerfx-samples-list-functions-addtopvalue",
+        "name": "pnp-powerfx-samples-table-functions",
         "version": "1.0.0.0",
         "source": "pnp",
         "creationDateTime": "2021-03-06T00:00:00.000Z",
         "updateDateTime": "2021-03-06T00:00:00.000Z",
         "title": "AddTopValue",
-        "shortDescription": "Adds a value to a list of values ready to use in a drop down box. Returns a single column, named Result, table.",
+        "shortDescription": "This is a `TableUtils` PowerApp Component containing Custom Functions that allow to transform a Record in a Table",
         "longDescription": [
-            "Adds a value to a list of values ready to use in a drop down box. Returns a single column, named Result, table."
+            "This is a `TableUtils` PowerApp Component containing Custom Functions that allow to transform a Record in a Table."
         ],
-        "url": "https://github.com/pnp/powerfx-samples/tree/main/samples/list-functions#addtopvalue",
+        "url": "https://github.com/pnp/powerfx-samples/tree/main/samples/table-functionse",
         "products": [
             "Power Apps",
             "Power Platform",
@@ -33,15 +33,15 @@
             {
                 "type": "image",
                 "order": 100,
-                "url": "https://github.com/pnp/powerfx-samples/raw/main/samples/list-functions/assets/AddTopValueImg.PNG",
-                "alt": "Add Top Value"
+                "url": "https://github.com/pnp/powerfx-samples/raw/main/samples/table-functions/assets/sonDiffToTableSample.PNG",
+                "alt": "Table sample"
             }
         ],
         "authors": [
             {
-                "gitHubAccount": "Laura-GB",
-                "name": "Laura GB",
-                "pictureUrl": "https://github.com/Laura-GB.png"
+                "gitHubAccount": "bsorrentino",
+                "name": "Bartolomeo Sorrentino",
+                "pictureUrl": "https://github.com/bsorrentino.png"
             }
         ],
         "references": [


### PR DESCRIPTION


|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        |  yes                               |
| New feature?    | no                                |
| New sample?     | no                               |
| Related issues? | n/a |

## What's in this Pull Request?

provides the Power Fx category to Power Fx samples so that they show up correctly in the sample gallery. Also adds a missing sample.json for a sample. 